### PR TITLE
Implement --gasPrice option

### DIFF
--- a/bin/testrpc
+++ b/bin/testrpc
@@ -4,5 +4,6 @@ var TestRPC = require('..');
 
 TestRPC.startServer(console, {
   port: argv.p || argv.port,
-  debug: argv.d || argv.debug
+  debug: argv.d || argv.debug,
+  gasPrice: argv.g || argv.gasPrice
 });

--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -30,6 +30,11 @@ Blockchain = function(logger, options) {
     });
   }
 
+  this.gasPriceVal = '1';
+  if (options.gasPrice) {
+    this.gasPriceVal = utils.stripHexPrefix(utils.intToHex(options.gasPrice));
+  }
+
   this.mine(this.createBlock());
 }
 
@@ -149,7 +154,7 @@ Blockchain.prototype.latestBlock = function() {
 }
 
 Blockchain.prototype.gasPrice = function() {
-  return '1';
+  return this.gasPriceVal;
 }
 
 Blockchain.prototype.getBalance = function(address, callback) {

--- a/test/requests.js
+++ b/test/requests.js
@@ -107,6 +107,42 @@ var tests = function(web3) {
     });
   });
 
+  describe("custom eth_gasPrice", function() {
+    it("should return gas price of 0xf", function(done) {
+      var server = TestRPC.server(logger, {gasPrice: 15});
+      var port = 12346;
+      server.listen(port, function() {
+        var oldprovider = web3.currentProvider;
+        web3.setProvider(new Web3.providers.HttpProvider("http://localhost:" + port));
+        web3.eth.getGasPrice(function(err, result) {
+          if (err) return done(err);
+          assert.deepEqual(result.toNumber(), 15);
+          server.close();
+          web3.setProvider(oldprovider);
+          done();
+        });
+      });
+    });
+  });
+
+  describe("custom eth_gasPrice in hex", function() {
+    it("should return gas price of 0xf", function(done) {
+      var server = TestRPC.server(logger, {gasPrice: 0xf});
+      var port = 12346;
+      server.listen(port, function() {
+        var oldprovider = web3.currentProvider;
+        web3.setProvider(new Web3.providers.HttpProvider("http://localhost:" + port));
+        web3.eth.getGasPrice(function(err, result) {
+          if (err) return done(err);
+          assert.deepEqual(result.toNumber(), 15);
+          server.close();
+          web3.setProvider(oldprovider);
+          done();
+        });
+      });
+    });
+  });
+
   describe("eth_getBalance", function() {
     it("should return initial balance", function(done) {
       web3.eth.getBalance(accounts[0], function(err, result) {


### PR DESCRIPTION
Implements the suggestion in https://github.com/ethereumjs/testrpc/issues/30 , and includes two tests to demonstrate that it works for a gas price expressed in hex and decimal. Command line option is `--gasPrice` or `-g`.