### PR TITLE
Update block gasLimit to be equal to Homestead

### DIFF
--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -136,7 +136,7 @@ Blockchain.prototype.createBlock = function() {
   var block = new Block();
   var parent = this.blocks.length != 0 ? this.blocks[this.blocks.length - 1] : null;
 
-  block.header.gasLimit = '0x2fefd8';
+  block.header.gasLimit = '0x47e7c4';
 
   // Ensure we have the right block number for the VM.
   block.header.number = to.hex(this.blocks.length);


### PR DESCRIPTION
Is there a reason this hasn't been done before I haven't run across? Without it, then there are contracts that work just fine on Morden/the actual network that can't be tested with `testrpc`...