### PR TITLE
Fix getTransactionReceipt for nonexistent transaction

### DIFF
--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -150,7 +150,13 @@ GethApiDouble.prototype.eth_getBlockByHash = function(tx_hash, include_transacti
 GethApiDouble.prototype.eth_getTransactionReceipt = function(hash, callback) {
   this.state.getTransactionReceipt(hash, function(err, receipt) {
     if (err) return callback(err);
-    callback(null, receipt.toJSON());
+
+    var result = null;
+
+    if (receipt){
+      result = receipt.toJSON();
+    }
+    callback(null, result);
   });
 };
 

--- a/test/requests.js
+++ b/test/requests.js
@@ -258,6 +258,15 @@ var tests = function(web3) {
       });
     });
 
+    it("should return null if asked for a receipt for a nonexistent transaction (eth_getTransactionReceipt)", function(done) {
+      web3.eth.getTransactionReceipt("0xdeadbeef", function(err, receipt) {
+        if (err) return done(err);
+
+        assert.equal(receipt, null, "Transaction receipt should be null");
+        done();
+      });
+    });
+
     it("should verify there's code at the address (eth_getCode)", function(done) {
       web3.eth.getCode(contractAddress, function(err, result) {
         if (err) return done(err);


### PR DESCRIPTION
If a receipt for a transaction that didn't exist was requested,
an error was thrown. Now it returns `null` like `geth`. I've modelled
the new code after the implementation of `eth_getTransactionByHash`,
which is clearly written to avoid the same issue there.

I've included a new test for this too (NB two tests fail, but
that's the case on master, too, so I've left those alone for 
now).