### PR TITLE
Fix looking at nonces of queued transactions

### DIFF
--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -192,18 +192,24 @@ BlockchainDouble.prototype.createBlock = function() {
 };
 
 BlockchainDouble.prototype.getQueuedNonce = function(address, callback) {
-  var nonce = 0;
+  var nonce = null;
 
   this.pending_transactions.forEach(function(tx) {
-    if (tx.from != address) return;
+    //tx.from and address are buffers, so cannot simply do
+    //tx.from==address
+    if (tx.from.toString('hex') != address.toString('hex')) return;
 
     var pending_nonce = to.number(tx.nonce);
-    if (pending_nonce > nonce) {
+    //If this is the first queued nonce for this address we found,
+    //or it's higher than the previous highest, note it.
+    if (nonce===null || pending_nonce > nonce) {
       nonce = pending_nonce;
     }
   });
 
-  if (nonce > 0) return callback(null, nonce);
+  //If we found a queued transaction nonce, return one higher
+  //than the highest we found
+  if (nonce!=null) return callback(null, nonce+1);
 
   this.stateTrie.get(address, function(err, val) {
     if (err) return callback(err);


### PR DESCRIPTION
Previously, no queued transactions would be found when looking for nonces due to buffers being objects, and so even if they contained the same data, they would never be found to be equal through a shallow `!=`. This isn't a concern for the current implementation, because transactions aren't queued for very long at all - they are mined as soon as they are received. This also means I can't really write a test that failed before this change - apologies for that!

However, I stumbled across this while working on adding a toggle for disabling mining a block as soon as a transaction is received. We are in a situation where we would like to test queuing a few transactions up, and then mine them together, and so being able to send transactions, not have a block mined, and then trigger a block with `evm_mine` would be useful. I've since heard rumours that such a feature is already in the pipeline though - is there any truth to that?