### PR TITLE
Add ability to toggle mining

### DIFF
--- a/bin/testrpc
+++ b/bin/testrpc
@@ -46,7 +46,6 @@ var options = {
   fork: argv.f || argv.fork || false,
   network_id: argv.i || argv.networkId,
   verbose: argv.v || argv.verbose,
-  no_mine_after_transaction: argv.n || argv.noMineAfterTransaction || false,
   logger: console
 }
 

--- a/bin/testrpc
+++ b/bin/testrpc
@@ -46,6 +46,7 @@ var options = {
   fork: argv.f || argv.fork || false,
   network_id: argv.i || argv.networkId,
   verbose: argv.v || argv.verbose,
+  no_mine_after_transaction: argv.n || argv.noMineAfterTransaction || false,
   logger: console
 }
 

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -9,6 +9,7 @@ var Trie = require("merkle-patricia-tree");
 var Web3 = require("web3");
 var utils = require("ethereumjs-util");
 var async = require('async');
+var Heap = require("heap");
 
 function BlockchainDouble(options) {
   var self = this;
@@ -200,6 +201,7 @@ BlockchainDouble.prototype.getQueuedNonce = function(address, callback) {
     if (tx.from.toString('hex') != address.toString('hex')) return;
 
     var pending_nonce = to.number(tx.nonce);
+    console.log('found nonce', pending_nonce);
     //If this is the first queued nonce for this address we found,
     //or it's higher than the previous highest, note it.
     if (nonce===null || pending_nonce > nonce) {
@@ -223,11 +225,67 @@ BlockchainDouble.prototype.queueTransaction = function(tx) {
   this.pending_transactions.push(tx);
 };
 
+BlockchainDouble.prototype.SortByPriceAndNonce = function(){
+  //Sorts transactions like I believe geth does.
+  //See the description of 'SortByPriceAndNonce' at
+  //https://github.com/ethereum/go-ethereum/blob/290e851f57f5d27a1d5f0f7ad784c836e017c337/core/types/transaction.go
+  //
+  var self = this;
+  var sortedByNonce = {};
+  for (idx in self.pending_transactions){
+    var tx = self.pending_transactions[idx]
+    console.log(tx.from.toString('hex'));
+    if (!sortedByNonce[tx.from.toString('hex')]){
+      sortedByNonce[tx.from.toString('hex')] = [tx];
+    }else{
+      Array.prototype.push.apply(sortedByNonce[tx.from.toString('hex')], [tx]);
+    }
+  }
+  var priceSort = function(a,b){
+    return parseInt(a.gasPrice.toString('hex'),16)-parseInt(b.gasPrice.toString('hex'),16);
+  }
+  var nonceSort = function(a,b){
+    return parseInt(b.nonce.toString('hex'),16)-parseInt(a.nonce.toString('hex'),16);
+  }
+
+  //Now sort each address by nonce
+  for (address in sortedByNonce){
+    console.log(address);
+    console.log(sortedByNonce[address]);
+    Array.prototype.sort.apply(sortedByNonce[address], nonceSort)
+  }
+
+  //Initialise a heap, sorted by price, for the head transaction from each account.
+  var heap = new Heap(priceSort);
+  for (address in sortedByNonce){
+    heap.push(sortedByNonce[address][0]);
+    //Remove the transaction from sortedByNonce
+    sortedByNonce[address].splice(0,1);
+  }
+
+  //Now reorder our transactions. Compare the next transactions from each account, and choose
+  //the one with the highest gas price.
+  sorted_transactions = [];
+  while (heap.size()>0){
+    best = heap.pop();
+    console.log('popped with nonce', best.nonce.toString('hex'), ' and gas limit ', best.gasLimit.toString('hex'));
+    if (sortedByNonce[best.from.toString('hex')].length>0){
+      //Push on the next transaction from this account
+      heap.push(sortedByNonce[address][0]);
+      sortedByNonce[address].splice(0,1);
+    }
+    Array.prototype.push.apply(sorted_transactions, [best]);
+  }
+  self.pending_transactions = sorted_transactions;
+}
+
 BlockchainDouble.prototype.processNextBlock = function(callback) {
   var self = this;
   var block = this.createBlock();
   var successfullyAddedTransactions = [];
 
+  //First, sort our transactions like geth does
+  this.SortByPriceAndNonce();
   function tryTransactionIdx(txnumber){
     Array.prototype.push.apply(block.transactions, [self.pending_transactions[txnumber]]);
     self._checkpointTrie();

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -198,10 +198,9 @@ BlockchainDouble.prototype.getQueuedNonce = function(address, callback) {
   this.pending_transactions.forEach(function(tx) {
     //tx.from and address are buffers, so cannot simply do
     //tx.from==address
-    if (tx.from.toString('hex') != address.toString('hex')) return;
+    if (to.hex(tx.from) != to.hex(address)) return;
 
     var pending_nonce = to.number(tx.nonce);
-    console.log('found nonce', pending_nonce);
     //If this is the first queued nonce for this address we found,
     //or it's higher than the previous highest, note it.
     if (nonce===null || pending_nonce > nonce) {
@@ -234,25 +233,22 @@ BlockchainDouble.prototype.SortByPriceAndNonce = function(){
   var sortedByNonce = {};
   for (idx in self.pending_transactions){
     var tx = self.pending_transactions[idx]
-    console.log(tx.from.toString('hex'));
-    if (!sortedByNonce[tx.from.toString('hex')]){
-      sortedByNonce[tx.from.toString('hex')] = [tx];
+    if (!sortedByNonce[to.hex(tx.from)]){
+      sortedByNonce[to.hex(tx.from)] = [tx];
     }else{
-      Array.prototype.push.apply(sortedByNonce[tx.from.toString('hex')], [tx]);
+      Array.prototype.push.apply(sortedByNonce[to.hex(tx.from)], [tx]);
     }
   }
   var priceSort = function(a,b){
-    return parseInt(a.gasPrice.toString('hex'),16)-parseInt(b.gasPrice.toString('hex'),16);
+    return parseInt(to.hex(b.gasPrice),16)-parseInt(to.hex(a.gasPrice),16);
   }
   var nonceSort = function(a,b){
-    return parseInt(b.nonce.toString('hex'),16)-parseInt(a.nonce.toString('hex'),16);
+    return parseInt(to.hex(a.nonce),16) - parseInt(to.hex(b.nonce),16)
   }
 
   //Now sort each address by nonce
   for (address in sortedByNonce){
-    console.log(address);
-    console.log(sortedByNonce[address]);
-    Array.prototype.sort.apply(sortedByNonce[address], nonceSort)
+    Array.prototype.sort.apply(sortedByNonce[address], [nonceSort])
   }
 
   //Initialise a heap, sorted by price, for the head transaction from each account.
@@ -268,8 +264,7 @@ BlockchainDouble.prototype.SortByPriceAndNonce = function(){
   sorted_transactions = [];
   while (heap.size()>0){
     best = heap.pop();
-    console.log('popped with nonce', best.nonce.toString('hex'), ' and gas limit ', best.gasLimit.toString('hex'));
-    if (sortedByNonce[best.from.toString('hex')].length>0){
+    if (sortedByNonce[to.hex(best.from)].length>0){
       //Push on the next transaction from this account
       heap.push(sortedByNonce[address][0]);
       sortedByNonce[address].splice(0,1);

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -280,8 +280,10 @@ BlockchainDouble.prototype.processNextBlock = function(callback) {
       generate: true,
     }, function(err, results) {
       //Remove transactions that were added from the pending transactions pool
-      for (idx in successfullyAddedTransactions){
-        self.pending_transactions.splice(idx,1);
+      //We go backwards so that deleting transactions doesn't mess up our
+      //indices
+      for (var i = successfullyAddedTransactions.length-1; i>=0; i--){
+        self.pending_transactions.splice(successfullyAddedTransactions[i],1);
       }
 
       if (err || results.error) {

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -192,18 +192,24 @@ BlockchainDouble.prototype.createBlock = function() {
 };
 
 BlockchainDouble.prototype.getQueuedNonce = function(address, callback) {
-  var nonce = 0;
+  var nonce = null;
 
   this.pending_transactions.forEach(function(tx) {
-    if (tx.from != address) return;
+    //tx.from and address are buffers, so cannot simply do
+    //tx.from==address
+    if (tx.from.toString('hex') != address.toString('hex')) return;
 
     var pending_nonce = to.number(tx.nonce);
-    if (pending_nonce > nonce) {
+    //If this is the first queued nonce for this address we found,
+    //or it's higher than the previous highest, note it.
+    if (nonce===null || pending_nonce > nonce) {
       nonce = pending_nonce;
     }
   });
 
-  if (nonce > 0) return callback(null, nonce);
+  //If we found a queued transaction nonce, return one higher
+  //than the highest we found
+  if (nonce!=null) return callback(null, nonce+1);
 
   this.stateTrie.get(address, function(err, val) {
     if (err) return callback(err);

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -226,83 +226,137 @@ BlockchainDouble.prototype.queueTransaction = function(tx) {
 BlockchainDouble.prototype.processNextBlock = function(callback) {
   var self = this;
   var block = this.createBlock();
+  var successfullyAddedTransactions = [];
 
-  Array.prototype.push.apply(block.transactions, this.pending_transactions);
+  function tryTransactionIdx(txnumber){
+    Array.prototype.push.apply(block.transactions, [self.pending_transactions[txnumber]]);
+    self._checkpointTrie();
+    self.vm.runBlock({block: block,
+      generate:true}, function(err,results){
+        //Regardless of whether we error'd or not, this was just
+        //an experiment to see if the transaction was good, so
+        //revert the trie
+        //
+        self._revertTrie();
+        if (err || results.error) {
+          err = err || results.error;
 
-  this._checkpointTrie();
+          if (err instanceof Error == false) {
+            err = new Error("VM error: " + err);
+          }
 
-  this.vm.runBlock({
-    block: block,
-    generate: true,
-  }, function(err, results) {
-    self.pending_transactions = [];
+          block.transactions.pop(); //Remove the bad transaction from the block
 
-    if (err || results.error) {
-      err = err || results.error;
+          //If this is the first queued transaction, it must be bad
+          //so throw after deleting it from pending
+          //transactions (transactions we don't try first might just not
+          //be able to fit in the current block due to gas);
 
-      if (err instanceof Error == false) {
-        err = new Error("VM error: " + err);
-      }
-
-      self._revertTrie();
-      //block.transactions.pop();
-
-      callback(err);
-      return;
-    }
-
-
-    var logs = [];
-    var receipts = [];
-
-    var totalBlockGasUsage = 0;
-
-    results.results.forEach(function(result) {
-      totalBlockGasUsage += to.number(result.gasUsed);
-    });
-
-    block.header.gasUsed = utils.toBuffer(to.hex(totalBlockGasUsage));
-
-    for (var v = 0; v < results.receipts.length; v++) {
-      var result = results.results[v];
-      var receipt = results.receipts[v];
-      var tx = block.transactions[v];
-      var tx_hash = tx.hash();
-      var tx_logs = [];
-
-      for (var i = 0; i < receipt.logs.length; i++) {
-        var log = receipt.logs[i];
-        var address = to.hex(log[0]);
-        var topics = []
-
-        for (var j = 0; j < log[1].length; j++) {
-          topics.push(to.hex(log[1][j]));
+          if (txnumber===0){
+            self.pending_transactions.splice(0,1);
+            callback(err);
+            return;
+          }
+        }else{
+          //Otherwise, went in the block okay.
+          //Note that we want to remove it from our transaction pool
+          Array.prototype.push.apply(successfullyAddedTransactions, [txnumber]);
         }
 
-        var data = to.hex(log[2]);
+        if (txnumber < self.pending_transactions.length-1){
+          return tryTransactionIdx(txnumber+1);
+        }else{
+          //Otherwise, mine the block as we've tried all the
+          //pending transactions for now
+          mineBlock();
+        }
+      });
+  }
 
-        var log = new Log({
-          logIndex: to.hex(i),
-          transactionIndex: to.hex(v),
-          transactionHash: tx_hash,
-          block: block,
-          address: address,
-          data: data,
-          topics: topics,
-          type: "mined"
-        });
-
-        logs.push(log);
-        tx_logs.push(log);
+  function mineBlock(){
+    self._checkpointTrie();
+    self.vm.runBlock({
+      block: block,
+      generate: true,
+    }, function(err, results) {
+      //Remove transactions that were added from the pending transactions pool
+      for (idx in successfullyAddedTransactions){
+        self.pending_transactions.splice(idx,1);
       }
 
-      receipts.push(new Receipt(tx, block, tx_logs, receipt.gasUsed, result.createdAddress));
-    }
+      if (err || results.error) {
+        //This is surprising, because we just tried this block and
+        //then reverted it after it was successful. But you can never be too
+        //careful...
+        err = err || results.error;
 
-    self.putBlock(block, logs, receipts);
+        if (err instanceof Error == false) {
+          err = new Error("VM error: " + err);
+        }
 
-    callback(null, results);
-  });
+        self._revertTrie();
+
+        callback(err);
+        return;
+      }
+
+
+      var logs = [];
+      var receipts = [];
+
+      var totalBlockGasUsage = 0;
+
+      results.results.forEach(function(result) {
+        totalBlockGasUsage += to.number(result.gasUsed);
+      });
+
+      block.header.gasUsed = utils.toBuffer(to.hex(totalBlockGasUsage));
+
+      for (var v = 0; v < results.receipts.length; v++) {
+        var result = results.results[v];
+        var receipt = results.receipts[v];
+        var tx = block.transactions[v];
+        var tx_hash = tx.hash();
+        var tx_logs = [];
+
+        for (var i = 0; i < receipt.logs.length; i++) {
+          var log = receipt.logs[i];
+          var address = to.hex(log[0]);
+          var topics = []
+
+          for (var j = 0; j < log[1].length; j++) {
+            topics.push(to.hex(log[1][j]));
+          }
+
+          var data = to.hex(log[2]);
+
+          var log = new Log({
+            logIndex: to.hex(i),
+            transactionIndex: to.hex(v),
+            transactionHash: tx_hash,
+            block: block,
+            address: address,
+            data: data,
+            topics: topics,
+            type: "mined"
+          });
+
+          logs.push(log);
+          tx_logs.push(log);
+        }
+
+        receipts.push(new Receipt(tx, block, tx_logs, receipt.gasUsed, result.createdAddress));
+      }
+
+      self.putBlock(block, logs, receipts);
+      callback(null, results);
+    });
+  }
+  if (self.pending_transactions.length > 0){
+    tryTransactionIdx(0);
+  } else {
+    mineBlock();
+  }
 };
 
 BlockchainDouble.prototype.getAccount = function(address, number, callback) {

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -51,6 +51,8 @@ StateManager = function(options) {
   if (options.gasPrice) {
     this.gasPriceVal = utils.stripHexPrefix(utils.intToHex(options.gasPrice));
   }
+
+  this.no_mine_after_transaction = options.no_mine_after_transaction;
 }
 
 StateManager.prototype.initialize = function(options, callback) {
@@ -338,10 +340,13 @@ StateManager.prototype.processTransaction = function(from, tx, callback) {
 
   this.blockchain.queueTransaction(tx);
 
+  var tx_hash = to.hex(tx.hash());
+  if (this.no_mine_after_transaction){
+    return callback(null, tx_hash);
+  }
+
   this.blockchain.processNextBlock(function(err, results) {
     if (err) return callback(err);
-
-    var tx_hash = to.hex(tx.hash());
 
     var result = results.results[0];
 

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -52,7 +52,7 @@ StateManager = function(options) {
     this.gasPriceVal = utils.stripHexPrefix(utils.intToHex(options.gasPrice));
   }
 
-  this.no_mine_after_transaction = options.no_mine_after_transaction;
+  this.no_mine_after_transaction = false;
 }
 
 StateManager.prototype.initialize = function(options, callback) {

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -361,6 +361,9 @@ StateManager.prototype.printTransactionReceipt = function(tx_hash, callback){
 StateManager.prototype.processBlocksUntilNoMoreTransactionsAdded = function(callback){
   var self = this;
   var prevPending = self.blockchain.pending_transactions.length;
+  if (prevPending===0){
+    return callback();
+  }
   self.blockchain.processNextBlock(function(err,results){
     if (err) return callback(err);
 

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -335,46 +335,66 @@ StateManager.prototype.sign = function(address, dataToSign) {
   return utils.addHexPrefix(r.concat(s, v));
 };
 
-StateManager.prototype.processTransaction = function(from, tx, callback) {
+StateManager.prototype.printTransactionReceipt = function(tx_hash, callback){
   var self = this;
 
-  this.blockchain.queueTransaction(tx);
+  self.blockchain.getTransactionReceipt(tx_hash, function(err, receipt) {
+    var block = self.blockchain.latestBlock();
+    receipt = receipt.toJSON();
 
-  var tx_hash = to.hex(tx.hash());
-  if (this.no_mine_after_transaction){
-    return callback(null, tx_hash);
-  }
+    self.logger.log("");
+    self.logger.log("  Transaction: " + tx_hash);
 
-  this.blockchain.processNextBlock(function(err, results) {
+    if (receipt.contractAddress != null) {
+      self.logger.log("  Contract created: " + receipt.contractAddress);
+    }
+
+    self.logger.log("  Gas usage: " + receipt.gasUsed);
+    self.logger.log("  Block Number: " + receipt.blockNumber);
+    self.logger.log("  Block Time: " + new Date(to.number(block.header.timestamp) * 1000).toString());
+    self.logger.log("");
+
+    callback(null, tx_hash);
+  });
+}
+
+StateManager.prototype.processBlocksUntilNoMoreTransactionsAdded = function(callback){
+  var self = this;
+  var prevPending = self.blockchain.pending_transactions.length;
+  self.blockchain.processNextBlock(function(err,results){
     if (err) return callback(err);
 
     var result = results.results[0];
-
     if (result.vm.exception != 1) {
-      callback(new Error("VM Exception while executing transaction: " + result.vm.exceptionError));
-      return;
+      return callback(new Error("VM Exception while executing transaction: " + result.vm.exceptionError));
+    }else if (self.blockchain.pending_transactions.length!==prevPending && self.blockchain.pending_transactions.length!==0){
+      //We added some transactions, and there are more to go
+      return self.processBlocksUntilNoMoreTransactionsAdded(callback);
+    }else{
+      //No more pending transactions - I guess we're done here.
+      callback();
     }
+  })
+}
 
-    var block = self.blockchain.latestBlock();
+StateManager.prototype.processTransaction = function(from, tx, callback) {
+  var self = this;
 
-    self.blockchain.getTransactionReceipt(tx_hash, function(err, receipt) {
-      receipt = receipt.toJSON();
+  self.blockchain.queueTransaction(tx);
 
-      self.logger.log("");
-      self.logger.log("  Transaction: " + tx_hash);
+  var tx_hash = to.hex(tx.hash());
 
-      if (receipt.contractAddress != null) {
-        self.logger.log("  Contract created: " + receipt.contractAddress);
-      }
+  if (self.no_mine_after_transaction){
+    return callback(null, tx_hash);
+  }
 
-      self.logger.log("  Gas usage: " + receipt.gasUsed);
-      self.logger.log("  Block Number: " + receipt.blockNumber);
-      self.logger.log("  Block Time: " + new Date(to.number(block.header.timestamp) * 1000).toString());
-      self.logger.log("");
+  self.processBlocksUntilNoMoreTransactionsAdded(function(err, results){
+    if (err){
+      return callback(err)
+    }
+    self.printTransactionReceipt(tx_hash, callback);
+  })
 
-      callback(null, tx_hash);
-    });
-  });
 };
 
 StateManager.prototype.getTransactionReceipt = function(hash, callback) {

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -251,7 +251,7 @@ GethApiDouble.prototype.miner_start = function(threads, callback) {
   });
 }
 
-GethApiDouble.prototype.miner_stop = function(threads, callback) {
+GethApiDouble.prototype.miner_stop = function(callback) {
   this.state.no_mine_after_transaction = true;
   callback(null, true);
 }

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -244,6 +244,19 @@ GethApiDouble.prototype.net_version = function(callback) {
   callback(null, this.state.net_version + "");
 };
 
+GethApiDouble.prototype.miner_start = function(threads, callback) {
+  this.state.no_mine_after_transaction = false;
+  //Mine [TODO: if we have pending transactions?]
+  this.state.blockchain.processNextBlock(function(err) {
+    callback(err, true);
+  });
+}
+
+GethApiDouble.prototype.miner_stop = function(threads, callback) {
+  this.state.no_mine_after_transaction = true;
+  callback(null, true);
+}
+
 /* Functions for testing purposes only. */
 
 GethApiDouble.prototype.evm_snapshot = function(callback) {

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -246,8 +246,7 @@ GethApiDouble.prototype.net_version = function(callback) {
 
 GethApiDouble.prototype.miner_start = function(threads, callback) {
   this.state.no_mine_after_transaction = false;
-  //Mine [TODO: if we have pending transactions?]
-  this.state.blockchain.processNextBlock(function(err) {
+  this.state.processBlocksUntilNoMoreTransactionsAdded(function(err) {
     callback(err, true);
   });
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ethereumjs-vm": "^1.3.0",
     "ethereumjs-wallet": "^0.6.0",
     "fake-merkle-patricia-tree": "^1.0.1",
+    "heap": "^0.2.6",
     "merkle-patricia-tree": "^2.1.2",
     "seedrandom": "^2.4.2",
     "shelljs": "^0.6.0",

--- a/test/queuedTransactions.js
+++ b/test/queuedTransactions.js
@@ -1,0 +1,91 @@
+var Web3 = require('web3');
+var TestRPC = require("../index.js");
+var assert = require('assert');
+
+
+
+var accounts;
+var web3 = new Web3(TestRPC.provider());
+
+before(function(done) {
+  web3.eth.getAccounts(function(err, accs) {
+    if (err) return done(err);
+
+    accounts = accs;
+    done();
+  });
+});
+
+beforeEach(function(done){
+  web3.currentProvider.sendAsync({
+    jsonrpc: "2.0",
+    method: "miner_stop",
+  }, done)
+});
+
+afterEach(function(done){
+  web3.currentProvider.sendAsync({
+    jsonrpc: "2.0",
+    method: "miner_start",
+    params: [1]
+  }, done)
+});
+
+
+describe("Ordering transactions", function() {
+  it("should order queued transactions correctly by nonce before adding to the block", function(done) {
+    var tx_data = {}
+    tx_data.to = accounts[1];
+    tx_data.from = accounts[0];
+    tx_data.value = 0x1;
+    tx_data.nonce = 0;
+    tx_data.gas = 21000;
+    web3.eth.sendTransaction(tx_data, function(err, tx) {
+      if (err){return done(err)}
+      tx_data.nonce=1;
+      web3.eth.sendTransaction(tx_data, function(err, tx){
+        if (err){return done(err)}
+        web3.currentProvider.sendAsync({
+          jsonrpc: "2.0",
+          method: "miner_start",
+          params: [1]
+        }, function(err,tx){
+          web3.eth.getBlock("latest", function(err, block) {
+            if (err) return done(err);
+            assert.equal(block.transactions.length, 2, "Latest block should have two transactions");
+            done();
+          });
+        })
+      })
+    })
+  });
+  it("should order queued transactions correctly by price before adding to the block", function(done) {
+    var tx_data = {}
+    tx_data.to = accounts[1];
+    tx_data.from = accounts[0];
+    tx_data.value = 0x1;
+    tx_data.gas = 21000;
+    tx_data.gasPrice = 0x1
+    web3.eth.sendTransaction(tx_data, function(err, tx) {
+      if (err){return done(err)}
+      tx_data.gasPrice=2;
+      tx_data.from = accounts[1];
+      web3.eth.sendTransaction(tx_data, function(err, tx){
+        if (err){return done(err)}
+        web3.currentProvider.sendAsync({
+          jsonrpc: "2.0",
+          method: "miner_start",
+          params: [1]
+        }, function(err,tx){
+          web3.eth.getBlock("latest", function(err, block) {
+            if (err) return done(err);
+            assert.equal(block.transactions.length, 2, "Latest block should have two transactions");
+            assert.equal(block.transactions[0].gasPrice.toNumber(),2)
+            assert.equal(block.transactions[1].gasPrice.toNumber(),1)
+            done();
+          });
+        })
+      })
+    })
+  });
+});

--- a/test/requests.js
+++ b/test/requests.js
@@ -563,6 +563,69 @@ var tests = function(web3) {
     });
   });
 
+  describe("miner_stop", function(){
+    it("should stop mining", function(done){
+      web3.currentProvider.sendAsync({
+        jsonrpc: "2.0",
+        method: "miner_stop",
+      }, function(err,result){
+        var tx_data = {}
+        tx_data.to = accounts[1];
+        tx_data.from = accounts[0];
+        tx_data.value = 0x1;
+
+        web3.eth.sendTransaction(tx_data, function(err, tx) {
+          if (err) return done(err);
+
+          web3.eth.getTransactionReceipt(tx, function(err, receipt) {
+            if (err) return done(err);
+
+            assert.equal(receipt, null);
+            web3.currentProvider.sendAsync({
+              jsonrpc: "2.0",
+              method: "miner_start",
+              params: [1]
+            }, function(err, result){
+              if (err) return done(err);
+              done();
+            })
+          });
+        });
+      })
+    })
+  });
+
+  describe("miner_start", function(){
+    it("should start mining", function(done){
+      web3.currentProvider.sendAsync({
+        jsonrpc: "2.0",
+        method: "miner_stop",
+      }, function(err,result){
+        web3.currentProvider.sendAsync({
+          jsonrpc: "2.0",
+          method: "miner_start",
+          params: [1]
+        }, function(err,result){
+          var tx_data = {}
+          tx_data.to = accounts[1];
+          tx_data.from = accounts[0];
+          tx_data.value = 0x1;
+
+
+          web3.eth.sendTransaction(tx_data, function(err, tx) {
+            if (err) return done(err);
+            //Check the receipt
+            web3.eth.getTransactionReceipt(tx, function(err, receipt) {
+              if (err) return done(err);
+              assert.notEqual(receipt, null); //i.e. receipt exists, so transaction was mined
+              done();
+            });
+          });
+        })
+      })
+    })
+  });
+
   describe("web3_sha3", function() {
     it("should hash the given input", function(done) {
       var input = "Tim is a swell guy.";


### PR DESCRIPTION
Firstly, **do not merge!**. This depends on #153, and moreover needs some discussion before getting merged.

As mentioned in #153, we've found ourselves want to make sure transactions are included in the same block for testing, which is not possible with `testrpc` yet because as soon as a transaction is received, it is mined into a block. ~~This PR is a possible implementation of a flag `--noMineAfterTransaction` that toggles this behaviour.~~

The block-building logic becomes more complicated with multiple possible transactions, and is where the majority of the changes in this PR are found. In summary, when a block is mined:

- Each transaction is added to the block in turn, starting with the first pending transaction. If the first pending transaction fails, the bad transaction is removed from the pool, then an error is thrown.
- If subsequent transactions cause the block to fail when added, they _might_ be okay, but the block is getting full due to the block gas limit, or they might be bad transactions themselves. An error is not thrown, the transaction is not yet removed from the pool, and the remaining transactions are tried in turn.
- In any of these cases, the state trie is reverted after the block is tested.
- Finally, the block is mined with the transactions that it was able to include in this greedy fashion, and the transactions successfully included are removed from the list of pending transactions.

This implementation doesn't currently break any existing behaviour (the tests that pass on master still pass here). Some tests should be written for this new functionality, however.

The code needs some cleanup (notably failing DRY quite badly), but I thought it prudent to get any other comments at this point that would be able to improve this new feature to the level needed to get it released.